### PR TITLE
basic float printing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ set(ZIG_STD_SRC
     "${CMAKE_SOURCE_DIR}/std/errno.zig"
     "${CMAKE_SOURCE_DIR}/std/rand.zig"
     "${CMAKE_SOURCE_DIR}/std/mem.zig"
+    "${CMAKE_SOURCE_DIR}/std/math.zig"
 )
 
 set(C_HEADERS_DEST "lib/zig/include")

--- a/std/math.zig
+++ b/std/math.zig
@@ -1,0 +1,25 @@
+pub fn f64_from_bits(bits: u64) -> f64 {
+    const bits2 = bits;
+    *(&f64)(&bits2)
+}
+
+pub fn f64_to_bits(f: f64) -> u64 {
+    const f2 = f;
+    *(&u64)(&f2)
+}
+
+pub fn f64_get_pos_inf() -> f64 {
+    f64_from_bits(0x7FF0000000000000)
+}
+
+pub fn f64_get_neg_inf() -> f64 {
+    f64_from_bits(0xFFF0000000000000)
+}
+
+pub fn f64_is_nan(f: f64) -> bool {
+    0x7FFFFFFFFFFFFFFF == f64_to_bits(f) // TODO improve to catch all cases
+}
+
+pub fn f64_is_inf(f: f64) -> bool {
+    f == f64_get_neg_inf() || f == f64_get_pos_inf()
+}

--- a/std/std.zig
+++ b/std/std.zig
@@ -268,7 +268,6 @@ pub fn buf_print_f64(out_buf: []u8, x: f64) -> isize {
 
     const bits = f64_to_bits(x);
     if (bits & (1 << 63) != 0) {
-        %%stdout.printf("neg\n");
         buf[0] = '-';
         len += 1;
     }

--- a/std/std.zig
+++ b/std/std.zig
@@ -246,15 +246,15 @@ pub fn buf_print_u64(out_buf: []u8, x: u64) -> isize {
 pub fn buf_print_f64(out_buf: []u8, x: f64) -> isize {
     if (x == f64_get_pos_inf()) {
         const buf2 = "+Inf";
-        @memcpy(&out_buf[0], &buf2[0], 4);
+        @memcpy(&out_buf[0], &buf2[0], buf2.len);
         return 4;
     } else if (x == f64_get_neg_inf()) {
         const buf2 = "-Inf";
-        @memcpy(&out_buf[0], &buf2[0], 4);
+        @memcpy(&out_buf[0], &buf2[0], buf2.len);
         return 4;
     } else if (f64_is_nan(x)) {
         const buf2 = "NaN";
-        @memcpy(&out_buf[0], &buf2[0], 3);
+        @memcpy(&out_buf[0], &buf2[0], buf2.len);
         return 3;
     }
 


### PR DESCRIPTION
This PR adds support for basic printing of f64. Note that the output is rather human-unfriendly. For example, `500.0` is printed as `8796093022208000*2^-44`.