### PR TITLE
Added code for generating nonnull attributes

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2905,6 +2905,10 @@ static void do_code_gen(CodeGen *g) {
             if (param_type->id == TypeTableEntryIdPointer) {
                 // when https://github.com/andrewrk/zig/issues/82 is fixed, add
                 // non null attribute here
+
+                ///`i` is arg index + 1
+                ///I think that 0 is the return index, but it has a named LLVM constant variable
+                LLVMZigAddNonNullAttr(fn_table_entry->fn_value, param_decl_i + 1);
             }
             if (is_byval) {
                 // TODO

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -140,6 +140,16 @@ LLVMValueRef LLVMZigBuildCall(LLVMBuilderRef B, LLVMValueRef Fn, LLVMValueRef *A
     return wrap(unwrap(B)->Insert(call_inst));
 }
 
+void LLVMZigAddNonNullAttr(LLVMValueRef fn, unsigned i)
+{
+    assert( isa<Function>(unwrap(fn)) );
+
+    Function *unwrapped_function = reinterpret_cast<Function*>(unwrap(fn));
+
+    unwrapped_function->addAttribute(i, Attribute::NonNull);
+}
+
+
 LLVMZigDIType *LLVMZigCreateDebugPointerType(LLVMZigDIBuilder *dibuilder, LLVMZigDIType *pointee_type,
         uint64_t size_in_bits, uint64_t align_in_bits, const char *name)
 {

--- a/src/zig_llvm.hpp
+++ b/src/zig_llvm.hpp
@@ -39,6 +39,7 @@ void LLVMZigOptimizeModule(LLVMTargetMachineRef targ_machine_ref, LLVMModuleRef 
 LLVMValueRef LLVMZigBuildCall(LLVMBuilderRef B, LLVMValueRef Fn, LLVMValueRef *Args,
         unsigned NumArgs, unsigned CC, const char *Name);
 
+void LLVMZigAddNonNullAttr(LLVMValueRef fn, unsigned i);
 
 LLVMZigDIType *LLVMZigCreateDebugPointerType(LLVMZigDIBuilder *dibuilder, LLVMZigDIType *pointee_type,
         uint64_t size_in_bits, uint64_t align_in_bits, const char *name);


### PR DESCRIPTION

Addresses part of [Issue 82](https://github.com/andrewrk/zig/issues/82): function pointer arguments are now emitted to LLVM with the nonnull.