### PR TITLE
Add --zig-std-dir

### DIFF
--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1220,6 +1220,7 @@ struct CodeGen {
     Buf *libc_lib_dir;
     Buf *libc_static_lib_dir;
     Buf *libc_include_dir;
+    Buf *zig_std_dir;
     Buf *dynamic_linker;
     Buf *linker_path;
     Buf *ar_path;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -84,6 +84,7 @@ CodeGen *codegen_create(Buf *root_source_dir, const ZigTarget *target) {
         g->libc_lib_dir = buf_create_from_str("");
         g->libc_static_lib_dir = buf_create_from_str("");
         g->libc_include_dir = buf_create_from_str("");
+        g->zig_std_dir = buf_create_from_str("");
         g->linker_path = buf_create_from_str("");
         g->ar_path = buf_create_from_str("");
         g->darwin_linker_version = buf_create_from_str("");
@@ -96,6 +97,7 @@ CodeGen *codegen_create(Buf *root_source_dir, const ZigTarget *target) {
         g->libc_lib_dir = buf_create_from_str(ZIG_LIBC_LIB_DIR);
         g->libc_static_lib_dir = buf_create_from_str(ZIG_LIBC_STATIC_LIB_DIR);
         g->libc_include_dir = buf_create_from_str(ZIG_LIBC_INCLUDE_DIR);
+        g->zig_std_dir = buf_create_from_str(ZIG_STD_DIR);
         g->linker_path = buf_create_from_str(ZIG_LD_PATH);
         g->ar_path = buf_create_from_str(ZIG_AR_PATH);
         g->darwin_linker_version = buf_create_from_str(ZIG_HOST_LINK_VERSION);
@@ -163,6 +165,11 @@ void codegen_set_libc_static_lib_dir(CodeGen *g, Buf *libc_static_lib_dir) {
 
 void codegen_set_libc_include_dir(CodeGen *g, Buf *libc_include_dir) {
     g->libc_include_dir = libc_include_dir;
+}
+
+void codegen_set_zig_std_dir(CodeGen *g, Buf *zig_std_dir) {
+    g->zig_std_dir = zig_std_dir;
+    g->std_package->root_src_dir = *zig_std_dir;
 }
 
 void codegen_set_dynamic_linker(CodeGen *g, Buf *dynamic_linker) {
@@ -4752,7 +4759,7 @@ void codegen_render_ast(CodeGen *g, FILE *f, int indent_size) {
 
 
 static ImportTableEntry *add_special_code(CodeGen *g, PackageTableEntry *package, const char *basename) {
-    Buf *std_dir = buf_create_from_str(ZIG_STD_DIR);
+    Buf *std_dir = g->zig_std_dir;
     Buf *code_basename = buf_create_from_str(basename);
     Buf path_to_code_src = BUF_INIT;
     os_path_join(std_dir, code_basename, &path_to_code_src);
@@ -4770,7 +4777,7 @@ static ImportTableEntry *add_special_code(CodeGen *g, PackageTableEntry *package
 }
 
 static PackageTableEntry *create_bootstrap_pkg(CodeGen *g) {
-    PackageTableEntry *package = new_package(ZIG_STD_DIR, "");
+    PackageTableEntry *package = new_package(buf_ptr(g->zig_std_dir), "");
     package->package_table.put(buf_create_from_str("std"), g->std_package);
     package->package_table.put(buf_create_from_str("@root"), g->root_package);
     return package;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -72,6 +72,7 @@ CodeGen *codegen_create(Buf *root_source_dir, const ZigTarget *target) {
     g->root_package = new_package(buf_ptr(root_source_dir), "");
     g->std_package = new_package(ZIG_STD_DIR, "index.zig");
     g->root_package->package_table.put(buf_create_from_str("std"), g->std_package);
+    g->zig_std_dir = buf_create_from_str(ZIG_STD_DIR);
 
 
     if (target) {
@@ -84,7 +85,6 @@ CodeGen *codegen_create(Buf *root_source_dir, const ZigTarget *target) {
         g->libc_lib_dir = buf_create_from_str("");
         g->libc_static_lib_dir = buf_create_from_str("");
         g->libc_include_dir = buf_create_from_str("");
-        g->zig_std_dir = buf_create_from_str("");
         g->linker_path = buf_create_from_str("");
         g->ar_path = buf_create_from_str("");
         g->darwin_linker_version = buf_create_from_str("");
@@ -97,7 +97,6 @@ CodeGen *codegen_create(Buf *root_source_dir, const ZigTarget *target) {
         g->libc_lib_dir = buf_create_from_str(ZIG_LIBC_LIB_DIR);
         g->libc_static_lib_dir = buf_create_from_str(ZIG_LIBC_STATIC_LIB_DIR);
         g->libc_include_dir = buf_create_from_str(ZIG_LIBC_INCLUDE_DIR);
-        g->zig_std_dir = buf_create_from_str(ZIG_STD_DIR);
         g->linker_path = buf_create_from_str(ZIG_LD_PATH);
         g->ar_path = buf_create_from_str(ZIG_AR_PATH);
         g->darwin_linker_version = buf_create_from_str(ZIG_HOST_LINK_VERSION);

--- a/src/codegen.hpp
+++ b/src/codegen.hpp
@@ -30,6 +30,7 @@ void codegen_set_out_name(CodeGen *codegen, Buf *out_name);
 void codegen_set_libc_lib_dir(CodeGen *codegen, Buf *libc_lib_dir);
 void codegen_set_libc_static_lib_dir(CodeGen *g, Buf *libc_static_lib_dir);
 void codegen_set_libc_include_dir(CodeGen *codegen, Buf *libc_include_dir);
+void codegen_set_zig_std_dir(CodeGen *codegen, Buf *zig_std_dir);
 void codegen_set_dynamic_linker(CodeGen *g, Buf *dynamic_linker);
 void codegen_set_linker_path(CodeGen *g, Buf *linker_path);
 void codegen_set_ar_path(CodeGen *g, Buf *ar_path);

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -33,7 +33,7 @@ static const char *get_libc_static_file(CodeGen *g, const char *file) {
 
 static Buf *build_o(CodeGen *parent_gen, const char *oname) {
     Buf *source_basename = buf_sprintf("%s.zig", oname);
-    Buf *std_dir_path = buf_create_from_str(ZIG_STD_DIR);
+    Buf *std_dir_path = parent_gen->zig_std_dir;
 
     ZigTarget *child_target = parent_gen->is_native_target ? nullptr : &parent_gen->zig_target;
     CodeGen *child_gen = codegen_create(std_dir_path, child_target);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,6 +35,7 @@ static int usage(const char *arg0) {
         "  --libc-lib-dir [path]        directory where libc crt1.o resides\n"
         "  --libc-static-lib-dir [path] directory where libc crtbegin.o resides\n"
         "  --libc-include-dir [path]    directory where libc stdlib.h resides\n"
+        "  --zig-std-dir [path]         directory where zig standard library resides\n"
         "  --dynamic-linker [path]      set the path to ld.so\n"
         "  --ld-path [path]             set the path to the linker\n"
         "  --ar-path [path]             set the path to ar\n"
@@ -117,6 +118,7 @@ int main(int argc, char **argv) {
     const char *libc_lib_dir = nullptr;
     const char *libc_static_lib_dir = nullptr;
     const char *libc_include_dir = nullptr;
+    const char *zig_std_dir = nullptr;
     const char *dynamic_linker = nullptr;
     const char *linker_path = nullptr;
     const char *ar_path = nullptr;
@@ -194,6 +196,8 @@ int main(int argc, char **argv) {
                     libc_static_lib_dir = argv[i];
                 } else if (strcmp(arg, "--libc-include-dir") == 0) {
                     libc_include_dir = argv[i];
+                } else if (strcmp(arg, "--zig-std-dir") == 0) {
+                    zig_std_dir = argv[i];
                 } else if (strcmp(arg, "--dynamic-linker") == 0) {
                     dynamic_linker = argv[i];
                 } else if (strcmp(arg, "--ld-path") == 0) {
@@ -356,6 +360,8 @@ int main(int argc, char **argv) {
                 codegen_set_libc_static_lib_dir(g, buf_create_from_str(libc_static_lib_dir));
             if (libc_include_dir)
                 codegen_set_libc_include_dir(g, buf_create_from_str(libc_include_dir));
+            if (zig_std_dir)
+                codegen_set_zig_std_dir(g, buf_create_from_str(zig_std_dir));
             if (dynamic_linker)
                 codegen_set_dynamic_linker(g, buf_create_from_str(dynamic_linker));
             if (linker_path)


### PR DESCRIPTION
So we can change `std` location between different versions, or keep a static binary compiled in a machine useful in another. It doesn't work with relative paths yet.