### PR TITLE
std/str.zig: Add 'concat' and 'join' functions

### DIFF
--- a/std/str.zig
+++ b/std/str.zig
@@ -1,5 +1,6 @@
 const assert = @import("index.zig").assert;
 
+pub const concat = join(u8);
 pub const eql = slice_eql(u8);
 
 pub fn slice_eql(T: type)(a: []const T, b: []const T) -> bool {
@@ -8,6 +9,15 @@ pub fn slice_eql(T: type)(a: []const T, b: []const T) -> bool {
         if (b[index] != item) return false;
     }
     return true;
+}
+
+pub fn join(T: type)(a: []T, b: []T) -> []T {
+    var result : [a.len + b.len]T = undefined;
+
+    @memcpy(result.ptr, a.ptr, a.len * @sizeof(T));
+    @memcpy((&T)((usize)(result.ptr) + (usize)(a.len * @sizeof(T))), b.ptr, b.len * @sizeof(T));
+
+    return result;
 }
 
 #attribute("test")


### PR DESCRIPTION
I needed them, so I thought they could be useful to everyone.