### PR TITLE
fix uninitialized variables

### DIFF
--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -305,8 +305,8 @@ static void end_float_token(Tokenize *t) {
     t->exponent_in_bin_or_dec += specified_exponent;
 
     uint64_t significand = t->cur_tok->data.num_lit.bignum.data.x_uint;
-    uint64_t significand_bits;
-    uint64_t exponent_bits;
+    uint64_t significand_bits = 0;
+    uint64_t exponent_bits = 0;
     if (significand == 0) {
         // 0 is all 0's
         significand_bits = 0;


### PR DESCRIPTION
On line number 330 of ‘[tokenizer.cpp](https://github.com/andrewrk/zig/blob/master/src/tokenizer.cpp#L330)’, ‘`significand_bits`’ and ‘`exponent_bits`’ may be accessed without an initialized value. It's always good to initialize variables, because if we try to access a value before it gets assigned any actual (non-garbage) value, then it results in undefined behavior.

Found by https://github.com/bryongloden/cppcheck