### PR TITLE
[parseh.cpp] fix the memory leak

### DIFF
--- a/src/parseh.cpp
+++ b/src/parseh.cpp
@@ -1038,6 +1038,7 @@ static TypeTableEntry *resolve_record_decl(Context *c, const RecordDecl *record_
         if (field_type->id == TypeTableEntryIdInvalid) {
             emit_warning(c, field_decl, "struct %s demoted to typedef - unresolved type\n", buf_ptr(bare_name));
             replace_with_fwd_decl(c, struct_type, full_type_name);
+            free(element_types);
             return struct_type;
         }
 


### PR DESCRIPTION
Greetings @andrewrk & co, on line number 1041 of '[parseh.cpp](https://github.com/andrewrk/zig/blob/master/src/parseh.cpp#L1041)' there is a memory leak, which is an error. The reason we should free is that memory is a finite resource within our running programs. Sure in very short running simple programs, failing to free memory won't have a noticeable effect. However on long running programs, failing to free memory means we will be consuming a finite resource without replenishing it. Eventually it will run out and our program will abruptly crash. This is why we must free memory.