### PR TITLE
Allow implicit cast from T to %?T

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "files.associations": {
+        "*.zig": "c",
+        "type_traits": "cpp",
+        "*.inc": "cpp"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "files.associations": {
+        "*.zig": "c",
+        "type_traits": "cpp",
+        "*.inc": "cpp",
+        "thread": "cpp"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "files.associations": {
-        "*.zig": "c",
-        "type_traits": "cpp",
-        "*.inc": "cpp"
-    }
-}

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -7091,8 +7091,6 @@ static IrInstruction *ir_analyze_cast(IrAnalyze *ira, IrInstruction *source_inst
                 return ira->codegen->invalid_instruction;
                 
             return cast2;
-        } else {
-            return ira->codegen->invalid_instruction;
         }
     }
 

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -5824,11 +5824,12 @@ static bool ir_num_lit_fits_in_other_type(IrAnalyze *ira, IrInstruction *instruc
         {
             return true;
         }
-    } else if ((other_type->id == TypeTableEntryIdNumLitFloat &&
-                const_val->data.x_bignum.kind == BigNumKindFloat) ||
-               (other_type->id == TypeTableEntryIdNumLitInt &&
-                const_val->data.x_bignum.kind == BigNumKindInt))
-    {
+    } else if ((other_type->id == TypeTableEntryIdNumLitFloat && const_val->data.x_bignum.kind == BigNumKindFloat) ||
+               (other_type->id == TypeTableEntryIdNumLitInt   && const_val->data.x_bignum.kind == BigNumKindInt  )) {
+        return true;
+    } else if ((other_type->id == TypeTableEntryIdMaybe &&
+                other_type->data.maybe.child_type->id == TypeTableEntryIdInt &&
+                const_val->data.x_bignum.kind == BigNumKindInt)) {
         return true;
     }
 

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -7091,6 +7091,13 @@ static IrInstruction *ir_analyze_cast(IrAnalyze *ira, IrInstruction *source_inst
                 return ira->codegen->invalid_instruction;
                 
             return cast2;
+        } else if (actual_type->id == TypeTableEntryIdNullLit) {
+            IrInstruction *cast1 = ir_analyze_null_to_maybe(ira, source_instr, value, wanted_type->data.error.child_type);
+            IrInstruction *cast2 = ir_analyze_cast(ira, source_instr, wanted_type, cast1);
+            if (type_is_invalid(cast2->value.type))
+                return ira->codegen->invalid_instruction;
+                
+            return cast2;
         }
     }
 

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -7081,18 +7081,13 @@ static IrInstruction *ir_analyze_cast(IrAnalyze *ira, IrInstruction *source_inst
     if (wanted_type->id == TypeTableEntryIdErrorUnion &&
         wanted_type->data.error.child_type->id == TypeTableEntryIdMaybe &&
         actual_type->id != TypeTableEntryIdMaybe) {
-        if (types_match_const_cast_only(wanted_type->data.error.child_type->data.maybe.child_type, actual_type)) {
+        if (types_match_const_cast_only(wanted_type->data.error.child_type->data.maybe.child_type, actual_type) || 
+            actual_type->id == TypeTableEntryIdNullLit ||
+            actual_type->id == TypeTableEntryIdNumLitInt ) {
             IrInstruction *cast1 = ir_analyze_cast(ira, source_instr, wanted_type->data.error.child_type, value);
             if (type_is_invalid(cast1->value.type))
                 return ira->codegen->invalid_instruction;
 
-            IrInstruction *cast2 = ir_analyze_cast(ira, source_instr, wanted_type, cast1);
-            if (type_is_invalid(cast2->value.type))
-                return ira->codegen->invalid_instruction;
-                
-            return cast2;
-        } else if (actual_type->id == TypeTableEntryIdNullLit) {
-            IrInstruction *cast1 = ir_analyze_null_to_maybe(ira, source_instr, value, wanted_type->data.error.child_type);
             IrInstruction *cast2 = ir_analyze_cast(ira, source_instr, wanted_type, cast1);
             if (type_is_invalid(cast2->value.type))
                 return ira->codegen->invalid_instruction;

--- a/test/cases/cast.zig
+++ b/test/cases/cast.zig
@@ -92,6 +92,13 @@ fn castToMaybeTypeError() {
     assert((??%%b).a == 1);
 }
 
+test "implicitly cast from int to %?T" {
+    const f: %?i32 = 1;
+    comptime const g: %?i32 = 1;
+
+    const h: %?i8 = 104;
+}
+
 test "return null from fn() -> %?&T" {
     const a = returnNullFromMaybeTypeErrorRef();
     const b = returnNullLitFromMaybeTypeErrorRef();

--- a/test/cases/cast.zig
+++ b/test/cases/cast.zig
@@ -91,3 +91,16 @@ fn castToMaybeTypeError() {
     const b: %?A = a;
     assert((??%%b).a == 1);
 }
+
+test "return null from fn() -> %?&T" {
+    const a = returnNullFromMaybeTypeErrorRef();
+    const b = returnNullLitFromMaybeTypeErrorRef();
+    assert(%%a == null and %%b == null);
+}
+fn returnNullFromMaybeTypeErrorRef() -> %?&A {
+    const a: ?&A = null;
+    return a;
+}
+fn returnNullLitFromMaybeTypeErrorRef() -> %?&A {
+    return null;
+}

--- a/test/cases/cast.zig
+++ b/test/cases/cast.zig
@@ -65,7 +65,6 @@ fn testPeerResolveArrayConstSlice(b: bool) {
     assert(mem.eql(u8, value2, "zz"));
 }
 
-
 test "integer literal to &const int" {
     const x: &const i32 = 3;
     assert(*x == 3);
@@ -74,4 +73,22 @@ test "integer literal to &const int" {
 test "string literal to &const []const u8" {
     const x: &const []const u8 = "hello";
     assert(mem.eql(u8, *x, "hello"));
+}
+
+
+test "valToNullErrorCast" {
+    castToMaybeTypeError();
+    comptime castToMaybeTypeError();
+}
+const A = struct {
+    a: i32,
+};
+fn castToMaybeTypeError() {
+    const x = i32(1);
+    const y: %?i32 = x;
+    assert(??%%y == 1);
+
+    const a = A{ .a = 1 };
+    const b: %?A = a;
+    assert((??%%b).a == 1);
 }

--- a/test/cases/cast.zig
+++ b/test/cases/cast.zig
@@ -76,16 +76,19 @@ test "string literal to &const []const u8" {
 }
 
 test "implicitly cast from T to %?T" {
-    castToMaybeTypeError();
-    comptime castToMaybeTypeError();
+    castToMaybeTypeError(1);
+    comptime castToMaybeTypeError(1);
 }
 const A = struct {
     a: i32,
 };
-fn castToMaybeTypeError() {
+fn castToMaybeTypeError(z: i32) {
     const x = i32(1);
     const y: %?i32 = x;
     assert(??%%y == 1);
+
+    const f = z;
+    const g: %?i32 = f;
 
     const a = A{ .a = 1 };
     const b: %?A = a;
@@ -95,8 +98,6 @@ fn castToMaybeTypeError() {
 test "implicitly cast from int to %?T" {
     const f: %?i32 = 1;
     comptime const g: %?i32 = 1;
-
-    const h: %?i8 = 104;
 }
 
 test "return null from fn() -> %?&T" {

--- a/test/cases/cast.zig
+++ b/test/cases/cast.zig
@@ -75,8 +75,7 @@ test "string literal to &const []const u8" {
     assert(mem.eql(u8, *x, "hello"));
 }
 
-
-test "valToNullErrorCast" {
+test "implicitly cast from T to %?T" {
     castToMaybeTypeError();
     comptime castToMaybeTypeError();
 }
@@ -87,9 +86,6 @@ fn castToMaybeTypeError() {
     const x = i32(1);
     const y: %?i32 = x;
     assert(??%%y == 1);
-
-    const g: %?i32 = 1;
-    assert( g == 1 );
 
     const a = A{ .a = 1 };
     const b: %?A = a;

--- a/test/cases/cast.zig
+++ b/test/cases/cast.zig
@@ -88,6 +88,9 @@ fn castToMaybeTypeError() {
     const y: %?i32 = x;
     assert(??%%y == 1);
 
+    const g: %?i32 = 1;
+    assert( g == 1 );
+
     const a = A{ .a = 1 };
     const b: %?A = a;
     assert((??%%b).a == 1);


### PR DESCRIPTION
At the moment, something like `const g: %?i32 = 1;` won't work, as `error: integer value 1 cannot be implicitly casted to type '?i32'`.

Should this implicit cast be allowed?