### PR TITLE
Add @offsetOf builtin function

### DIFF
--- a/doc/langref.md
+++ b/doc/langref.md
@@ -314,6 +314,10 @@ for the current target.
 
 The result is a target-specific compile time constant.
 
+### @offsetOf(comptime T: type, comptime field_name: [] const u8) -> (number literal)
+
+This function returns the byte offset of a field relative to its containing struct.
+
 ### Overflow Arithmetic
 
 These functions take an integer type, two variables of the specified type,

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1190,6 +1190,7 @@ enum BuiltinFnId {
     BuiltinFnIdIntToPtr,
     BuiltinFnIdEnumTagName,
     BuiltinFnIdFieldParentPtr,
+    BuiltinFnIdOffsetOf,
 };
 
 struct BuiltinFnEntry {
@@ -1742,6 +1743,7 @@ enum IrInstructionId {
     IrInstructionIdEnumTagName,
     IrInstructionIdSetFnRefInline,
     IrInstructionIdFieldParentPtr,
+    IrInstructionIdOffsetOf,
 };
 
 struct IrInstruction {
@@ -2501,6 +2503,13 @@ struct IrInstructionFieldParentPtr {
     IrInstruction *field_name;
     IrInstruction *field_ptr;
     TypeStructField *field;
+};
+
+struct IrInstructionOffsetOf {
+    IrInstruction base;
+
+    IrInstruction *type_value;
+    IrInstruction *field_name;
 };
 
 static const size_t slice_ptr_index = 0;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2888,6 +2888,7 @@ static LLVMValueRef ir_render_instruction(CodeGen *g, IrExecutable *executable, 
         case IrInstructionIdDeclRef:
         case IrInstructionIdSwitchVar:
         case IrInstructionIdSetFnRefInline:
+        case IrInstructionIdOffsetOf:        
             zig_unreachable();
         case IrInstructionIdReturn:
             return ir_render_return(g, executable, (IrInstructionReturn *)instruction);
@@ -4548,6 +4549,7 @@ static void define_builtin_fns(CodeGen *g) {
     create_builtin_fn(g, BuiltinFnIdIntToPtr, "intToPtr", 2);
     create_builtin_fn(g, BuiltinFnIdEnumTagName, "enumTagName", 1);
     create_builtin_fn(g, BuiltinFnIdFieldParentPtr, "fieldParentPtr", 3);
+    create_builtin_fn(g, BuiltinFnIdOffsetOf, "offsetOf", 2);
 }
 
 static void add_compile_var(CodeGen *g, const char *name, ConstExprValue *value) {

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -885,6 +885,14 @@ static void ir_print_field_parent_ptr(IrPrint *irp, IrInstructionFieldParentPtr 
     fprintf(irp->f, ")");
 }
 
+static void ir_print_offset_of(IrPrint *irp, IrInstructionOffsetOf *instruction) {
+    fprintf(irp->f, "@offset_of(");
+    ir_print_other_instruction(irp, instruction->type_value);
+    fprintf(irp->f, ",");
+    ir_print_other_instruction(irp, instruction->field_name);
+    fprintf(irp->f, ")");
+}
+
 static void ir_print_instruction(IrPrint *irp, IrInstruction *instruction) {
     ir_print_prefix(irp, instruction);
     switch (instruction->id) {
@@ -1174,6 +1182,9 @@ static void ir_print_instruction(IrPrint *irp, IrInstruction *instruction) {
             break;
         case IrInstructionIdFieldParentPtr:
             ir_print_field_parent_ptr(irp, (IrInstructionFieldParentPtr *)instruction);
+            break;
+        case IrInstructionIdOffsetOf:
+            ir_print_offset_of(irp, (IrInstructionOffsetOf *)instruction);
             break;
     }
     fprintf(irp->f, "\n");

--- a/test/cases/cast.zig
+++ b/test/cases/cast.zig
@@ -90,15 +90,20 @@ fn castToMaybeTypeError(z: i32) {
     const f = z;
     const g: %?i32 = f;
 
-    const a = A{ .a = 1 };
+    const a = A{ .a = z };
     const b: %?A = a;
     assert((??%%b).a == 1);
 }
 
 test "implicitly cast from int to %?T" {
-    const f: %?i32 = 1;
-    comptime const g: %?i32 = 1;
+    implicitIntLitToMaybe();
+    comptime implicitIntLitToMaybe();
 }
+fn implicitIntLitToMaybe() {
+    const f: ?i32 = 1;
+    const g: %?i32 = 1;
+}
+
 
 test "return null from fn() -> %?&T" {
     const a = returnNullFromMaybeTypeErrorRef();

--- a/test/cases/sizeof_and_typeof.zig
+++ b/test/cases/sizeof_and_typeof.zig
@@ -6,3 +6,29 @@ test "sizeofAndTypeOf" {
 }
 const x: u16 = 13;
 const z: @typeOf(x) = 19;
+
+const A = struct {
+    a: u8,
+    b: u32,
+    c: u8,
+};
+
+const P = packed struct {
+    a: u8,
+    b: u32,
+    c: u8,
+};
+
+test "offsetOf" {
+    // Packed structs have fixed memory layout
+    const p: P = undefined;
+    assert(@offsetOf(P, "a") == 0);
+    assert(@offsetOf(@typeOf(p), "b") == 1);
+    assert(@offsetOf(@typeOf(p), "c") == 5);
+
+    // Non-packed struct fields can be moved/padded
+    const a: A = undefined;
+    assert(usize(&a.a) - usize(&a) == @offsetOf(A, "a"));
+    assert(usize(&a.b) - usize(&a) == @offsetOf(@typeOf(a), "b"));
+    assert(usize(&a.c) - usize(&a) == @offsetOf(@typeOf(a), "c"));
+}


### PR DESCRIPTION
Cleaned up version of my previous pull request, adds built in function to give a field's offset within a struct.